### PR TITLE
Unification hints

### DIFF
--- a/doc/syntax.bnf
+++ b/doc/syntax.bnf
@@ -65,6 +65,10 @@ reserved "why3"
 <qident> ::=
   | {<ident> "."}* <ident>
 
+// Variable of a pattern
+<pvar> ::=
+  | "&" - {<ident> | "_"}
+
 <property> ::=
   | "constant"
   | "injective"
@@ -84,7 +88,7 @@ reserved "why3"
   | "@"? <qident>
   | "_"
   | "?" - <ident> {"[" <term> {"," <term>}* "]"}?
-  | "&" - {<ident> | "_"} {"[" <term> {"," <term>}* "]"}?
+  | <pvar> {"[" <term> {"," <term>}* "]"}?
   | "(" <term> ")"
   | "{" <term> "}"
   | <term> <term>
@@ -115,7 +119,7 @@ reserved "why3"
 
 // Unification hint
 <hint> ::=
-  | <patt> "≡" <patt> "→" <term> "≡" <term> {"," <term> "≡" <term>}*
+  | <patt> "≡" <patt> "→" <pvar> "≡" <term> {"," <term> "≡" <term>}*
 
 // Rewrite pattern
 <rw_patt> ::=

--- a/doc/syntax.bnf
+++ b/doc/syntax.bnf
@@ -13,6 +13,7 @@ reserved "definition"
 reserved "focus"
 reserved "in"
 reserved "injective"
+reserved "hint"
 reserved "let"
 reserved "open"
 reserved "print"
@@ -111,6 +112,10 @@ reserved "why3"
   | <patt> "→" <term>
 
 // TODO rule naming, positive / negative
+
+// Unification hint
+<hint> ::=
+  | <patt> "≡" <patt> "→" <term> "≡" <term> {"," <term> "≡" <term>}*
 
 // Rewrite pattern
 <rw_patt> ::=

--- a/src/handle.ml
+++ b/src/handle.ml
@@ -153,7 +153,7 @@ let handle_cmd : sig_state -> p_command -> sig_state * proof_data option =
       (* Approximately same processing as rules without SR checking. *)
       let hs = List.map (scope_rule ss) hs in
       let add_hint (s,h,r) =
-        let hu = StrMap.find "hint_unif" ss.pervasives in
+        let hu = StrMap.find "hint_unif" Pervasives.(!(Sign.pervasives)) in
         assert (s == hu);
         hu.sym_rules := !(hu.sym_rules) @ [r.elt];
         out 3 "(hint) %a\n" Print.pp_rule (hu,h,r.elt)

--- a/src/handle.ml
+++ b/src/handle.ml
@@ -149,17 +149,12 @@ let handle_cmd : sig_state -> p_command -> sig_state * proof_data option =
           List.iter write_tree syms
         end;
       (ss, None)
-  | P_hints(hs)                  ->
+  | P_hint(h)                    ->
       (* Approximately same processing as rules without SR checking. *)
-      let hs = List.map (scope_rule ss) hs in
+      let h = scope_hint ss h in
       let hu = List.assoc "hint_unif" Sign.pervasives in
-      let add_hint (s,h,r) =
-        (* All hints must concern the [hint_unif] symbol *)
-        assert (s == hu);
-        hu.sym_rules := !(hu.sym_rules) @ [r.elt];
-        out 3 "(hint) %a\n" Print.pp_rule (hu,h,r.elt)
-      in
-      List.iter add_hint hs;
+      hu.sym_rules := !(hu.sym_rules) @ [h.elt];
+      out 3 "(hint) %a\n" Print.pp_rule (hu,Nothing,h.elt);
       Tree.update_dtree hu;
       if Pervasives.(!write_trees) then
         begin

--- a/src/handle.ml
+++ b/src/handle.ml
@@ -152,7 +152,7 @@ let handle_cmd : sig_state -> p_command -> sig_state * proof_data option =
   | P_hint(h)                    ->
       (* Approximately same processing as rules without SR checking. *)
       let h = scope_hint ss h in
-      let hu = List.assoc "hint_unif" Sign.pervasives in
+      let hu = Sign.Unif_hints.atom in
       hu.sym_rules := !(hu.sym_rules) @ [h.elt];
       out 3 "(hint) %a\n" Print.pp_rule (hu,Nothing,h.elt);
       Tree.update_dtree hu;

--- a/src/handle.ml
+++ b/src/handle.ml
@@ -152,7 +152,7 @@ let handle_cmd : sig_state -> p_command -> sig_state * proof_data option =
   | P_hints(hs)                  ->
       (* Approximately same processing as rules without SR checking. *)
       let hs = List.map (scope_rule ss) hs in
-      let hu = StrMap.find "hint_unif" Sign.pervasives in
+      let hu = List.assoc "hint_unif" Sign.pervasives in
       let add_hint (s,h,r) =
         (* All hints must concern the [hint_unif] symbol *)
         assert (s == hu);

--- a/src/handle.ml
+++ b/src/handle.ml
@@ -153,7 +153,7 @@ let handle_cmd : sig_state -> p_command -> sig_state * proof_data option =
       (* Approximately same processing as rules without SR checking. *)
       let hs = List.map (scope_rule ss) hs in
       let add_hint (s,h,r) =
-        let hu = StrMap.find "hint_unif" Pervasives.(!(Sign.pervasives)) in
+        let hu = StrMap.find "hint_unif" Sign.pervasives in
         assert (s == hu);
         hu.sym_rules := !(hu.sym_rules) @ [r.elt];
         out 3 "(hint) %a\n" Print.pp_rule (hu,h,r.elt)

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -156,6 +156,7 @@ let _compute_    = KW.create "compute"
 let _constant_   = KW.create "constant"
 let _definition_ = KW.create "definition"
 let _focus_      = KW.create "focus"
+let _hint_       = KW.create "hint"
 let _in_         = KW.create "in"
 let _injective_  = KW.create "injective"
 let _intro_      = KW.create "assume"
@@ -580,6 +581,8 @@ let parser cmd =
                   Option.get Terms.Defin p,s,al,a)
   | _rule_ r:rule rs:{_:_and_ rule}*
       -> P_rules(r::rs)
+  | _hint_ r:rule rs:{_:_and_ rule}*
+      -> P_hints(r::rs)
   | e:exposition? _definition_ s:ident al:arg* ao:{":" term}? "≔" t:term
       -> P_definition(Option.get Terms.Public e,false,s,al,ao,t)
   | e:exposition? st:statement (ts,pe):proof

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -451,7 +451,7 @@ let parser rule =
 
 (** [unif] parses a unification problem. *)
 let parser unif =
-  | term "~" term
+  | term "≡" term
 
 (** [hint] is a parser for a unification hint. *)
 let parser hint =

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -449,13 +449,15 @@ let term = term PFunc
 let parser rule =
   | l:term "→" r:term -> Pos.in_pos _loc (l, r)
 
-(** [unif] parses a unification problem. *)
-let parser unif =
-  | term "≡" term
+(** [sub_unif] parses a sub-unification problem, that is, a unification
+    problem on the right-hand side of a hint. *)
+let parser sub_unif =
+  | v:patt "≡" t:term -> (Pos.in_pos _loc (P_Patt(v,[||])), t)
 
 (** [hint] is a parser for a unification hint. *)
 let parser hint =
-  | u:unif "→" r:unif rs:{"," unif}* -> Pos.in_pos _loc (u,r,rs)
+  | u:{term "≡" term} "→" r:sub_unif rs:{"," sub_unif}* ->
+      Pos.in_pos _loc (u,r,rs)
 
 (** [rw_patt_spec] is a parser for a rewrite pattern specification. *)
 let parser rw_patt_spec =

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -457,7 +457,7 @@ let parser sub_unif =
 (** [hint] is a parser for a unification hint. *)
 let parser hint =
   | u:{term "≡" term} "→" r:sub_unif rs:{"," sub_unif}* ->
-      Pos.in_pos _loc (u,r,rs)
+      Pos.in_pos _loc (u,r::rs)
 
 (** [rw_patt_spec] is a parser for a rewrite pattern specification. *)
 let parser rw_patt_spec =

--- a/src/parser.ml
+++ b/src/parser.ml
@@ -449,6 +449,14 @@ let term = term PFunc
 let parser rule =
   | l:term "→" r:term -> Pos.in_pos _loc (l, r)
 
+(** [unif] parses a unification problem. *)
+let parser unif =
+  | term "~" term
+
+(** [hint] is a parser for a unification hint. *)
+let parser hint =
+  | u:unif "→" r:unif rs:{"," unif}* -> Pos.in_pos _loc (u,r,rs)
+
 (** [rw_patt_spec] is a parser for a rewrite pattern specification. *)
 let parser rw_patt_spec =
   | t:term                          -> P_rw_Term(t)
@@ -581,8 +589,8 @@ let parser cmd =
                   Option.get Terms.Defin p,s,al,a)
   | _rule_ r:rule rs:{_:_and_ rule}*
       -> P_rules(r::rs)
-  | _hint_ r:rule rs:{_:_and_ rule}*
-      -> P_hints(r::rs)
+  | _hint_ h:hint
+      -> P_hint(h)
   | e:exposition? _definition_ s:ident al:arg* ao:{":" term}? "≔" t:term
       -> P_definition(Option.get Terms.Public e,false,s,al,ao,t)
   | e:exposition? st:statement (ts,pe):proof

--- a/src/pretty.ml
+++ b/src/pretty.ml
@@ -109,12 +109,12 @@ let pp_p_rule : p_rule pp = fun oc r ->
   Format.fprintf oc "@[<hov 3>rule %a@ → %a@]@?" pp_p_term lhs pp_p_term rhs
 
 let pp_p_hint : p_hint pp = fun oc h ->
-  let (l,r,rs) = h.elt in
+  let (l,rs) = h.elt in
   let pp_unif oc (l,r) =
     Format.fprintf oc "@[%a@ ~ %a@]@?" pp_p_term l pp_p_term r
   in
   let pp_unifs = List.pp (pp_unif) ", " in
-  Format.fprintf oc "@[<hov 3>hint %a@ → %a@]@?" pp_unif l pp_unifs (r::rs)
+  Format.fprintf oc "@[<hov 3>hint %a@ → %a@]@?" pp_unif l pp_unifs rs
 
 let pp_p_proof_end : p_proof_end pp = fun oc e ->
   match e with

--- a/src/pretty.ml
+++ b/src/pretty.ml
@@ -108,6 +108,14 @@ let pp_p_rule : p_rule pp = fun oc r ->
   let (lhs, rhs) = r.elt in
   Format.fprintf oc "@[<hov 3>rule %a@ → %a@]@?" pp_p_term lhs pp_p_term rhs
 
+let pp_p_hint : p_hint pp = fun oc h ->
+  let (l,r,rs) = h.elt in
+  let pp_unif oc (l,r) =
+    Format.fprintf oc "@[%a@ ~ %a@]@?" pp_p_term l pp_p_term r
+  in
+  let pp_unifs = List.pp (pp_unif) ", " in
+  Format.fprintf oc "@[<hov 3>hint %a@ → %a@]@?" pp_unif l pp_unifs (r::rs)
+
 let pp_p_proof_end : p_proof_end pp = fun oc e ->
   match e with
   | P_proof_qed   -> Format.pp_print_string oc "qed"
@@ -191,8 +199,8 @@ let pp_command : p_command pp = fun oc cmd ->
       out " :@ @[<hov>%a@]" pp_p_term a
   | P_rules(rs)                     ->
       out "%a" (List.pp pp_p_rule "\n") rs
-  | P_hints(hs)                     ->
-      out "%a" (List.pp pp_p_rule "\n") hs
+  | P_hint(h)                       ->
+      out "%a" pp_p_hint h
   | P_definition(e,_,s,args,ao,t)   ->
       out "@[<hov 2>%adefinition %a" pp_expo e pp_ident s;
       List.iter (out " %a" pp_p_arg) args;

--- a/src/pretty.ml
+++ b/src/pretty.ml
@@ -191,6 +191,8 @@ let pp_command : p_command pp = fun oc cmd ->
       out " :@ @[<hov>%a@]" pp_p_term a
   | P_rules(rs)                     ->
       out "%a" (List.pp pp_p_rule "\n") rs
+  | P_hints(hs)                     ->
+      out "%a" (List.pp pp_p_rule "\n") hs
   | P_definition(e,_,s,args,ao,t)   ->
       out "@[<hov 2>%adefinition %a" pp_expo e pp_ident s;
       List.iter (out " %a" pp_p_arg) args;

--- a/src/print.ml
+++ b/src/print.ml
@@ -18,6 +18,9 @@ let print_implicits : bool ref = Console.register_flag "print_implicits" false
 (** Flag controlling the printing of the context in unification. *)
 let print_contexts : bool ref = Console.register_flag "print_contexts" false
 
+(** Flag controling the printing of implicit arguments. *)
+let print_meta_type : bool ref = Console.register_flag "print_meta_type" false
+
 (** [pp_symbol h oc s] prints the name of the symbol [s] to channel [oc] using
     the printing hint [h] to decide qualification. *)
 let pp_symbol : pp_hint -> sym pp = fun h oc s ->
@@ -33,11 +36,14 @@ let pp_tvar : tvar pp = fun oc x ->
   Format.pp_print_string oc (Bindlib.name_of x)
 
 (** [pp_meta oc m] prints the uninstantiated meta-variable [m] to [oc]. *)
-let pp_meta : meta pp = fun oc m ->
-  Format.pp_print_string oc (meta_name m)
+let rec pp_meta : meta pp = fun oc m ->
+  if !print_meta_type then
+    Format.fprintf oc "(%s:%a)" (meta_name m) pp_term !(m.meta_type)
+  else
+    Format.pp_print_string oc (meta_name m)
 
 (** [pp_term oc t] prints the term [t] to the channel [oc]. *)
-let pp_term : term pp = fun oc t ->
+and pp_term : term pp = fun oc t ->
   let out = Format.fprintf in
   (* The possible priority levels are [`Func] (top level, including
      abstraction or product), [`Appl] (application) and [`Atom] (smallest

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -52,7 +52,7 @@ let find_sym : prt:bool -> prv:bool -> bool -> sig_state -> qident ->
     | []                               -> (* Symbol in scope. *)
         begin
           try (fst (StrMap.find s st.in_scope), Nothing) with Not_found ->
-          try (StrMap.find s Pervasives.(!(Sign.pervasives)), Nothing) with Not_found ->
+          try (StrMap.find s Sign.pervasives, Nothing) with Not_found ->
           let txt = if b then " or variable" else "" in
           fatal pos "Unbound symbol%s [%s]." txt s
         end

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -12,7 +12,6 @@ open Env
 (** State of the signature, including aliasing and accessible symbols. *)
 type sig_state =
   { signature  : Sign.t                    (** Current signature.   *)
-  ; pervasives : sym StrMap.t              (** Pervasive symbols    *)
   ; in_scope   : (sym * Pos.popt) StrMap.t (** Symbols in scope.    *)
   ; aliases    : module_path StrMap.t      (** Established aliases. *)
   ; builtins   : sym StrMap.t              (** Builtin symbols.     *) }
@@ -20,7 +19,6 @@ type sig_state =
 (** [empty_sig_state] is an empty signature state, without symbols/aliases. *)
 let empty_sig_state : Sign.t -> sig_state = fun sign ->
   { signature  = sign
-  ; pervasives = Sign.pervasives
   ; in_scope   = StrMap.empty
   ; aliases    = StrMap.empty
   ; builtins   = StrMap.empty }
@@ -54,7 +52,7 @@ let find_sym : prt:bool -> prv:bool -> bool -> sig_state -> qident ->
     | []                               -> (* Symbol in scope. *)
         begin
           try (fst (StrMap.find s st.in_scope), Nothing) with Not_found ->
-          try (StrMap.find s st.pervasives, Nothing) with Not_found ->
+          try (StrMap.find s Pervasives.(!(Sign.pervasives)), Nothing) with Not_found ->
           let txt = if b then " or variable" else "" in
           fatal pos "Unbound symbol%s [%s]." txt s
         end

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -11,17 +11,17 @@ open Env
 
 (** State of the signature, including aliasing and accessible symbols. *)
 type sig_state =
-  { signature  : Sign.t                    (** Current signature.   *)
-  ; in_scope   : (sym * Pos.popt) StrMap.t (** Symbols in scope.    *)
-  ; aliases    : module_path StrMap.t      (** Established aliases. *)
-  ; builtins   : sym StrMap.t              (** Builtin symbols.     *) }
+  { signature : Sign.t                    (** Current signature.   *)
+  ; in_scope  : (sym * Pos.popt) StrMap.t (** Symbols in scope.    *)
+  ; aliases   : module_path StrMap.t      (** Established aliases. *)
+  ; builtins  : sym StrMap.t              (** Builtin symbols.     *) }
 
 (** [empty_sig_state] is an empty signature state, without symbols/aliases. *)
 let empty_sig_state : Sign.t -> sig_state = fun sign ->
-  { signature  = sign
-  ; in_scope   = StrMap.empty
-  ; aliases    = StrMap.empty
-  ; builtins   = StrMap.empty }
+  { signature = sign
+  ; in_scope  = StrMap.empty
+  ; aliases   = StrMap.empty
+  ; builtins  = StrMap.empty }
 
 (** [open_sign ss sign] extends the signature state [ss] with every symbol  of
     the signature [sign].  This has the effect of putting these symbols in the

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -52,7 +52,7 @@ let find_sym : prt:bool -> prv:bool -> bool -> sig_state -> qident ->
     | []                               -> (* Symbol in scope. *)
         begin
           try (fst (StrMap.find s st.in_scope), Nothing) with Not_found ->
-          try (StrMap.find s Sign.pervasives, Nothing) with Not_found ->
+          try (List.assoc s Sign.pervasives, Nothing) with Not_found ->
           let txt = if b then " or variable" else "" in
           fatal pos "Unbound symbol%s [%s]." txt s
         end

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -518,7 +518,7 @@ let scope_rule : sig_state -> p_rule -> sym * pp_hint * rule loc = fun ss r ->
     ones. Unlike rewriting rules, unification hints may generate new
     metavariables. TODO: handle new variables generation. *)
 let scope_hint : sig_state -> p_hint -> rule loc = fun ss h ->
-  let (p_l, p_r, p_rs) = h.elt in
+  let (p_l, p_rs) = h.elt in
   (* Get pattern variables of [l] and [r] and verify that they are
      algebraic. *)
   let alg_patt_vars (l,r) =
@@ -531,10 +531,7 @@ let scope_hint : sig_state -> p_hint -> rule loc = fun ss h ->
   (* Compute the pattern variables. *)
   let pvs =
     let pvs_lhs = alg_patt_vars p_l in
-    let pvs_rhs =
-      let rest = List.map alg_patt_vars p_rs in
-      List.concat (alg_patt_vars p_r :: rest)
-    in
+    let pvs_rhs = List.concat (List.map alg_patt_vars p_rs) in
     List.map (fun m -> (m, List.assoc m pvs_lhs)) [] @ pvs_rhs in
   let map = List.mapi (fun i (m,_) -> (m,i)) pvs in
   (* Like [Basics.add_args] but for parser level terms. *)
@@ -561,7 +558,7 @@ let scope_hint : sig_state -> p_hint -> rule loc = fun ss h ->
     let names = Array.of_list (List.map fst map) in
     let vars = Bindlib.new_mvar te_mkfree names in
     let rhs =
-      let unif_probs = List.map mk_unif_pb (p_r::p_rs) in
+      let unif_probs = List.map mk_unif_pb p_rs in
       let p_rhs = add_args Sign.Unif_hints.p_list unif_probs in
       let map = Array.map2 (fun n v -> (n,v)) names vars in
       let mode = M_RHS(Array.to_list map, true) in

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -452,9 +452,9 @@ let patt_vars : p_term -> (string * int) list * string list =
     with Not_found -> ((id.elt, Array.length ts) :: pvs, nl)
   and arg_patt_vars acc xs =
     match xs with
-    | []                       -> acc
-    | (_, None,    _   ) :: xs -> arg_patt_vars acc xs
-    | (_, Some(a), _) :: xs    -> arg_patt_vars (patt_vars acc a) xs
+    | []                    -> acc
+    | (_, None   , _) :: xs -> arg_patt_vars acc xs
+    | (_, Some(a), _) :: xs -> arg_patt_vars (patt_vars acc a) xs
   in
   patt_vars ([],[])
 
@@ -506,10 +506,8 @@ let scope_rule : sig_state -> p_rule -> sym * pp_hint * rule loc = fun ss r ->
   let vars = Bindlib.new_mvar te_mkfree names in
   let rhs =
     let map = Array.map2 (fun n v -> (n,v)) names vars in
-    let t =
-      scope (M_RHS(Array.to_list map, is_private sym))
-        ss Env.empty p_rhs
-    in Bindlib.unbox (Bindlib.bind_mvar vars t)
+    let mode = M_RHS(Array.to_list map, is_private sym) in
+    Bindlib.unbox (Bindlib.bind_mvar vars (scope mode ss Env.empty p_rhs))
   in
   (* We also store [pvs] to facilitate confluence / termination checking. *)
   let vars = Array.of_list pvs in

--- a/src/scope.ml
+++ b/src/scope.ml
@@ -11,17 +11,19 @@ open Env
 
 (** State of the signature, including aliasing and accessible symbols. *)
 type sig_state =
-  { signature : Sign.t                    (** Current signature.   *)
-  ; in_scope  : (sym * Pos.popt) StrMap.t (** Symbols in scope.    *)
-  ; aliases   : module_path StrMap.t      (** Established aliases. *)
-  ; builtins  : sym StrMap.t              (** Builtin symbols.     *) }
+  { signature  : Sign.t                    (** Current signature.   *)
+  ; pervasives : sym StrMap.t              (** Pervasive symbols    *)
+  ; in_scope   : (sym * Pos.popt) StrMap.t (** Symbols in scope.    *)
+  ; aliases    : module_path StrMap.t      (** Established aliases. *)
+  ; builtins   : sym StrMap.t              (** Builtin symbols.     *) }
 
 (** [empty_sig_state] is an empty signature state, without symbols/aliases. *)
 let empty_sig_state : Sign.t -> sig_state = fun sign ->
-  { signature = sign
-  ; in_scope  = StrMap.empty
-  ; aliases   = StrMap.empty
-  ; builtins  = StrMap.empty }
+  { signature  = sign
+  ; pervasives = Sign.pervasives
+  ; in_scope   = StrMap.empty
+  ; aliases    = StrMap.empty
+  ; builtins   = StrMap.empty }
 
 (** [open_sign ss sign] extends the signature state [ss] with every symbol  of
     the signature [sign].  This has the effect of putting these symbols in the
@@ -52,6 +54,7 @@ let find_sym : prt:bool -> prv:bool -> bool -> sig_state -> qident ->
     | []                               -> (* Symbol in scope. *)
         begin
           try (fst (StrMap.find s st.in_scope), Nothing) with Not_found ->
+          try (StrMap.find s st.pervasives, Nothing) with Not_found ->
           let txt = if b then " or variable" else "" in
           fatal pos "Unbound symbol%s [%s]." txt s
         end

--- a/src/sign.ml
+++ b/src/sign.ml
@@ -30,10 +30,18 @@ type t =
    list. This association list then maps definable symbols of the external
    module to additional reduction rules defined in the current signature. *)
 
+(** Special symbol for unification hints. Practically, the term
+     [Symb(hint_unif,_) t u] represents the unification of [t] and [u]. *)
+let hint_unif : sym =
+  {sym_name="hint_unif"; sym_type=ref Kind; sym_path=[];
+   sym_def=ref None; sym_impl=[];sym_tree=ref Tree_types.empty_dtree;
+   sym_prop=Defin; sym_expo=Public; sym_rules=ref []}
+
 (** [create path] creates an empty signature with module path [path]. *)
 let create : module_path -> t = fun sign_path ->
+  let sign_builtins = ref (StrMap.singleton "hint_unif" hint_unif) in
   { sign_path; sign_symbols = ref StrMap.empty; sign_deps = ref PathMap.empty
-  ; sign_builtins = ref StrMap.empty; sign_unops = ref StrMap.empty
+  ; sign_builtins; sign_unops = ref StrMap.empty
   ; sign_binops = ref StrMap.empty; sign_idents = ref StrSet.empty }
 
 (** [find sign name] finds the symbol named [name] in [sign] if it exists, and

--- a/src/sign.ml
+++ b/src/sign.ml
@@ -31,7 +31,7 @@ type t =
    module to additional reduction rules defined in the current signature. *)
 
 (** [pervasives] contains the initial signature with pervasive symbols. *)
-let pervasives: sym StrMap.t Pervasives.ref =
+let pervasives: sym StrMap.t =
   (* Special symbol for unification hints. Practically, the term
      [Symb(hint_unif,_) t u] represents the unification of [t] and [u]. *)
   let hint_unif : sym =
@@ -39,7 +39,7 @@ let pervasives: sym StrMap.t Pervasives.ref =
     ; sym_def=ref None; sym_impl=[];sym_tree=ref Tree_types.empty_dtree
     ; sym_prop=Defin; sym_expo=Public; sym_rules=ref [] }
   in
-  Pervasives.ref (StrMap.singleton "hint_unif" hint_unif)
+  StrMap.singleton "hint_unif" hint_unif
 
 (** [create path] creates an empty signature with module path [path]. *)
 let create : module_path -> t = fun sign_path ->

--- a/src/sign.ml
+++ b/src/sign.ml
@@ -31,7 +31,7 @@ type t =
    module to additional reduction rules defined in the current signature. *)
 
 (** [pervasives] contains the initial signature with pervasive symbols. *)
-let pervasives: sym StrMap.t =
+let pervasives: sym StrMap.t Pervasives.ref =
   (* Special symbol for unification hints. Practically, the term
      [Symb(hint_unif,_) t u] represents the unification of [t] and [u]. *)
   let hint_unif : sym =
@@ -39,7 +39,7 @@ let pervasives: sym StrMap.t =
     ; sym_def=ref None; sym_impl=[];sym_tree=ref Tree_types.empty_dtree
     ; sym_prop=Defin; sym_expo=Public; sym_rules=ref [] }
   in
-  StrMap.singleton "hint_unif" hint_unif
+  Pervasives.ref (StrMap.singleton "hint_unif" hint_unif)
 
 (** [create path] creates an empty signature with module path [path]. *)
 let create : module_path -> t = fun sign_path ->

--- a/src/sign.ml
+++ b/src/sign.ml
@@ -31,7 +31,7 @@ type t =
    module to additional reduction rules defined in the current signature. *)
 
 (** [pervasives] contains the initial signature with pervasive symbols. *)
-let pervasives: sym StrMap.t =
+let pervasives: (string * sym) list =
   (* Special symbol for unification hints. Practically, the term
      [Symb(hint_unif,_) t u] represents the unification of [t] and [u]. *)
   let hint_unif : sym =
@@ -39,7 +39,9 @@ let pervasives: sym StrMap.t =
     ; sym_def=ref None; sym_impl=[];sym_tree=ref Tree_types.empty_dtree
     ; sym_prop=Defin; sym_expo=Public; sym_rules=ref [] }
   in
-  StrMap.singleton "hint_unif" hint_unif
+  let hint_conj = {hint_unif with sym_name="hint_conj"}
+  in
+  [("hint_conj", hint_conj); ("hint_unif", hint_unif)]
 
 (** [create path] creates an empty signature with module path [path]. *)
 let create : module_path -> t = fun sign_path ->

--- a/src/sign.ml
+++ b/src/sign.ml
@@ -30,18 +30,27 @@ type t =
    list. This association list then maps definable symbols of the external
    module to additional reduction rules defined in the current signature. *)
 
-(** [pervasives] contains the initial signature with pervasive symbols. *)
-let pervasives: (string * sym) list =
-  (* Special symbol for unification hints. Practically, the term
-     [Symb(hint_unif,_) t u] represents the unification of [t] and [u]. *)
-  let hint_unif : sym =
-    { sym_name="hint_unif"; sym_type=ref Kind; sym_path=[]
+(** Some definitions for unification hints. *)
+module Unif_hints = struct
+
+  (** Symbol representing an atomic unification problem. The term [atom t u]
+      represents [t =? u]. *)
+  let atom : sym =
+    { sym_name="unif_atom"; sym_type=ref Kind; sym_path=[]
     ; sym_def=ref None; sym_impl=[];sym_tree=ref Tree_types.empty_dtree
     ; sym_prop=Defin; sym_expo=Public; sym_rules=ref [] }
-  in
-  let hint_conj = {hint_unif with sym_name="hint_conj"}
-  in
-  [("hint_conj", hint_conj); ("hint_unif", hint_unif)]
+
+  let p_atom : p_term = Pos.none (P_Iden(Pos.none ([], "unif_atom"), false))
+
+  (** Symbol for a list of atoms. *)
+  let list : sym = {atom with sym_name = "unif_list"}
+
+  let p_list : p_term = Pos.none (P_Iden(Pos.none ([], "unif_list"), false))
+
+  (** Mapping from symbol names to names. *)
+  let map : (string * sym) list =
+    [(atom.sym_name, atom); (list.sym_name, list)]
+end
 
 (** [create path] creates an empty signature with module path [path]. *)
 let create : module_path -> t = fun sign_path ->

--- a/src/sign.ml
+++ b/src/sign.ml
@@ -30,18 +30,21 @@ type t =
    list. This association list then maps definable symbols of the external
    module to additional reduction rules defined in the current signature. *)
 
-(** Special symbol for unification hints. Practically, the term
+(** [pervasives] contains the initial signature with pervasive symbols. *)
+let pervasives: sym StrMap.t =
+  (* Special symbol for unification hints. Practically, the term
      [Symb(hint_unif,_) t u] represents the unification of [t] and [u]. *)
-let hint_unif : sym =
-  {sym_name="hint_unif"; sym_type=ref Kind; sym_path=[];
-   sym_def=ref None; sym_impl=[];sym_tree=ref Tree_types.empty_dtree;
-   sym_prop=Defin; sym_expo=Public; sym_rules=ref []}
+  let hint_unif : sym =
+    { sym_name="hint_unif"; sym_type=ref Kind; sym_path=[]
+    ; sym_def=ref None; sym_impl=[];sym_tree=ref Tree_types.empty_dtree
+    ; sym_prop=Defin; sym_expo=Public; sym_rules=ref [] }
+  in
+  StrMap.singleton "hint_unif" hint_unif
 
 (** [create path] creates an empty signature with module path [path]. *)
 let create : module_path -> t = fun sign_path ->
-  let sign_builtins = ref (StrMap.singleton "hint_unif" hint_unif) in
   { sign_path; sign_symbols = ref StrMap.empty; sign_deps = ref PathMap.empty
-  ; sign_builtins; sign_unops = ref StrMap.empty
+  ; sign_builtins = ref StrMap.empty; sign_unops = ref StrMap.empty
   ; sign_binops = ref StrMap.empty; sign_idents = ref StrSet.empty }
 
 (** [find sign name] finds the symbol named [name] in [sign] if it exists, and

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -80,6 +80,15 @@ and p_arg = ident option list * p_type option * bool
 (** Parser-level rewriting rule representation. *)
 type p_rule = (p_patt * p_term) loc
 
+(** Parser-level unification hint. *)
+type p_hint =
+  ( (p_patt * p_patt)
+  (* Left-hand side, initial unification problem. *)
+  * (p_term * p_term)
+  (* First unification sub-problem. *)
+  * (p_term * p_term) list
+  (* Rest of unification sub-problems. *)) loc
+
 (** Rewrite pattern specification. *)
 type p_rw_patt =
   | P_rw_Term           of p_term
@@ -180,7 +189,7 @@ type p_command_aux =
   (** Symbol declaration. *)
   | P_rules      of p_rule list
   (** Rewriting rule declarations. *)
-  | P_hints      of p_rule list
+  | P_hint       of p_hint
   (** Unification hints declarations. *)
   | P_definition of Terms.expo * bool * ident * p_arg list * p_type option
                   * p_term

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -82,12 +82,7 @@ type p_rule = (p_patt * p_term) loc
 
 (** Parser-level unification hint. *)
 type p_hint =
-  ( (p_patt * p_patt)
-  (* Left-hand side, initial unification problem. *)
-  * (p_term * p_term)
-  (* First unification sub-problem. *)
-  * (p_term * p_term) list
-  (* Rest of unification sub-problems. *)) loc
+  ((p_patt * p_patt) * (p_term * p_term) list) loc
 
 (** Rewrite pattern specification. *)
 type p_rw_patt =

--- a/src/syntax.ml
+++ b/src/syntax.ml
@@ -180,6 +180,8 @@ type p_command_aux =
   (** Symbol declaration. *)
   | P_rules      of p_rule list
   (** Rewriting rule declarations. *)
+  | P_hints      of p_rule list
+  (** Unification hints declarations. *)
   | P_definition of Terms.expo * bool * ident * p_arg list * p_type option
                   * p_term
   (** Definition of a symbol (unfoldable). *)

--- a/src/unif.ml
+++ b/src/unif.ml
@@ -393,7 +393,7 @@ and try_hints : sym StrMap.t -> unif_constrs -> unif_constrs option =
                constraints *)
             Some(solve {no_problems with to_solve})
         | _     -> assert false
-      with No_match -> try_hints builtins cs
+      with No_match -> Option.map (fun cs -> c :: cs) (try_hints builtins cs)
 
 (** [solve builtins flag problems] attempts to solve [problems], after having
    sets the value of [can_instantiate] to [flag].  If there is no solution,

--- a/src/unif.ml
+++ b/src/unif.ml
@@ -80,7 +80,7 @@ let instantiate : meta -> term array -> term -> bool = fun m ts u ->
 let try_hints : Ctxt.t -> term -> term -> unif_constrs option =
   fun ctx s t ->
   (* Symbol used to represent the unification relation. *)
-  let hint_unif = StrMap.find "hint_unif" Sign.pervasives in
+  let hint_unif = List.assoc "hint_unif" Sign.pervasives in
   (* Symbol used to represent the conjunction of unification problems. *)
   (* FIXME *)
   if !log_enabled then log_unif "hint [%a]" pp_constr (ctx,s,t);

--- a/src/unif.ml
+++ b/src/unif.ml
@@ -355,20 +355,12 @@ and solve_aux : ctxt -> term -> term -> problems -> unif_constrs =
 
   | (_          , _          ) -> error ()
 
-and try_hints : problems -> unif_constrs option =
-  fun ({unsolved; to_solve; _} as pb) ->
+and try_hints : sym StrMap.t -> problems -> unif_constrs option =
+  fun builtins ({unsolved; to_solve; _} as pb) ->
   (* Symbol used to represent the unification relation. *)
-  let hint_unif = {sym_name="un";sym_type=ref Kind;sym_path=[];
-                   sym_def=ref None;sym_impl=[];
-                   sym_tree=ref Tree_types.empty_dtree;sym_prop=Defin;
-                   sym_expo=Public;sym_rules=ref []}
-  in
+  let hint_unif = StrMap.find "hint_unif" builtins in
   (* Symbol used to represent the conjunction of unification problems. *)
-  (* let hint_conj = {sym_name="un";sym_type=ref Kind;sym_path=[];
-   *                  sym_def=ref None;sym_impl=[];
-   *                  sym_tree=ref Tree_types.empty_dtree;sym_prop=Defin;
-   *                  sym_expo=Public;sym_rules=ref []}
-   * in *)
+  (* FIXME *)
   match unsolved with
   | []            -> Some(to_solve)
   | c::cs ->
@@ -403,6 +395,6 @@ and try_hints : problems -> unif_constrs option =
    the value [None] is returned. Otherwise [Some(cs)] is returned, where the
    list [cs] is a list of unsolved convertibility constraints. *)
 let solve : sym StrMap.t -> bool -> problems -> unif_constrs option =
-  fun _builtins b p ->
+  fun builtins b p ->
   can_instantiate := b;
-  try Some (solve p) with Unsolvable -> try_hints p
+  try Some (solve p) with Unsolvable -> try_hints builtins p

--- a/src/unif.ml
+++ b/src/unif.ml
@@ -358,7 +358,7 @@ and solve_aux : ctxt -> term -> term -> problems -> unif_constrs =
 and try_hints : sym StrMap.t -> unif_constrs -> unif_constrs option =
   fun builtins cs ->
   (* Symbol used to represent the unification relation. *)
-  let hint_unif = StrMap.find "hint_unif" Pervasives.(!(Sign.pervasives)) in
+  let hint_unif = StrMap.find "hint_unif" Sign.pervasives in
   (* Symbol used to represent the conjunction of unification problems. *)
   (* FIXME *)
   match cs with
@@ -387,6 +387,8 @@ and try_hints : sym StrMap.t -> unif_constrs -> unif_constrs option =
         match ts with
         | [s;t] ->
             let to_solve = (ctx, s, t) :: cs in
+            if !log_enabled then
+              log_unif (gre "hint [%a]") pp_constr (ctx,s,t);
             (* FIXME: we will potentially re fail on not processed failed
                constraints *)
             Some(solve {no_problems with to_solve})

--- a/src/unif.ml
+++ b/src/unif.ml
@@ -99,10 +99,9 @@ let try_hints : Ctxt.t -> term -> term -> unif_constrs option =
     in
     let rec subpb_in t =
       match Basics.get_args (unfold t) with
-      | (Symb(u,_),[s;t]) ->
-          if u == hint_unif then [(ctx,s,t)] else
-          if u == hint_conj then subpb_in s @ subpb_in t
-          else assert false (* Ill structured term *)
+      | (Symb(u,_),[s;t]) when u == hint_unif -> [(ctx,s,t)]
+      | (Symb(u,_),ts   ) when u == hint_conj ->
+          List.concat (List.map subpb_in ts)
       | _                 -> assert false
     in
     let subpbs = subpb_in rhs in

--- a/src/unif.ml
+++ b/src/unif.ml
@@ -79,13 +79,9 @@ let instantiate : meta -> term array -> term -> bool = fun m ts u ->
     declared unification hints. *)
 let try_hints : Ctxt.t -> term -> term -> unif_constrs option =
   fun ctx s t ->
-  (* Symbol used to represent the unification relation. *)
-  let hint_unif = List.assoc "hint_unif" Sign.pervasives in
-  (* Symbol used to represent the conjunction of unification problems. *)
-  let hint_conj = List.assoc "hint_conj" Sign.pervasives in
   if !log_enabled then log_unif "hint [%a]" pp_constr (ctx,s,t);
   let exception No_match in
-  let tree = !(hint_unif.sym_tree) in
+  let tree = !(Sign.Unif_hints.atom.sym_tree) in
   try
     let rhs =
       match Eval.tree_walk tree [s;t] with
@@ -99,8 +95,8 @@ let try_hints : Ctxt.t -> term -> term -> unif_constrs option =
     in
     let rec subpb_in t =
       match Basics.get_args (unfold t) with
-      | (Symb(u,_),[s;t]) when u == hint_unif -> [(ctx,s,t)]
-      | (Symb(u,_),ts   ) when u == hint_conj ->
+      | (Symb(u,_),[s;t]) when u == Sign.Unif_hints.atom -> [(ctx,s,t)]
+      | (Symb(u,_),ts   ) when u == Sign.Unif_hints.list ->
           List.concat (List.map subpb_in ts)
       | _                 -> assert false
     in

--- a/tests/OK/unif_hint.lp
+++ b/tests/OK/unif_hint.lp
@@ -5,3 +5,7 @@ symbol Bool: TYPE
 rule T bool → Bool
 
 hint hint_unif (T &x) Bool → hint_unif &x bool
+
+symbol f : (Bool ⇒ Bool) ⇒ U
+
+type f (λx: T _, x)

--- a/tests/OK/unif_hint.lp
+++ b/tests/OK/unif_hint.lp
@@ -36,6 +36,9 @@ rule plus z &n      → &n
 injective symbol I (n: Nat): TYPE
 symbol H (n: Nat): I n ⇒ Nat
 symbol iz: I z
+//    &x ≡ z   &y ≡ z
+// -------------------
+//    plus &x &y ≡ z
 hint hint_unif (plus &x &y) z → hint_conj (hint_unif &x z) (hint_unif &y z)
 // Trigger the unification problem plus ?1 ?2 ≡ z
 compute H (plus _ _) iz

--- a/tests/OK/unif_hint.lp
+++ b/tests/OK/unif_hint.lp
@@ -4,6 +4,10 @@ symbol T: U ⇒ TYPE
 symbol bool: U
 symbol Bool: TYPE
 rule T bool → Bool
+
+//   &x ≡ bool
+// --------------
+//  T &x ≡ Bool
 hint hint_unif (T &x) Bool → hint_unif &x bool
 
 symbol f : (Bool ⇒ Bool) ⇒ U
@@ -13,7 +17,25 @@ type f (λx: T _, x)
 symbol Nat: TYPE
 symbol nat: U
 rule T nat → Nat
+
+//   &x ≡ nat
+// -------------
+//  T &x ≡ Nat
 hint hint_unif (T &x) Nat → hint_unif &x nat
 
 symbol G: ∀(x: Bool) (y: Nat), TYPE
 type λx: T _, λy: T _, G x y
+
+// Need several hints
+symbol z: Nat
+symbol s: Nat ⇒ Nat
+symbol plus : Nat ⇒ Nat ⇒ Nat
+rule plus z &n      → &n
+ and plus (s &m) &n → s (plus &m &n)
+
+injective symbol I (n: Nat): TYPE
+symbol H (n: Nat): I n ⇒ Nat
+symbol iz: I z
+hint hint_unif (plus &x &y) z → hint_conj (hint_unif &x z) (hint_unif &y z)
+// Trigger the unification problem plus ?1 ?2 ≡ z
+compute H (plus _ _) iz

--- a/tests/OK/unif_hint.lp
+++ b/tests/OK/unif_hint.lp
@@ -1,11 +1,19 @@
+// Simple unification hints
 symbol U: TYPE
 symbol T: U ⇒ TYPE
 symbol bool: U
 symbol Bool: TYPE
 rule T bool → Bool
-
 hint hint_unif (T &x) Bool → hint_unif &x bool
 
 symbol f : (Bool ⇒ Bool) ⇒ U
 
 type f (λx: T _, x)
+
+symbol Nat: TYPE
+symbol nat: U
+rule T nat → Nat
+hint hint_unif (T &x) Nat → hint_unif &x nat
+
+symbol G: ∀(x: Bool) (y: Nat), TYPE
+type λx: T _, λy: T _, G x y

--- a/tests/OK/unif_hint.lp
+++ b/tests/OK/unif_hint.lp
@@ -8,7 +8,7 @@ rule T bool → Bool
 //   &x ≡ bool
 // --------------
 //  T &x ≡ Bool
-hint hint_unif (T &x) Bool → hint_unif &x bool
+hint (T &x) ~ Bool → &x ~ bool
 
 symbol f : (Bool ⇒ Bool) ⇒ U
 
@@ -21,7 +21,7 @@ rule T nat → Nat
 //   &x ≡ nat
 // -------------
 //  T &x ≡ Nat
-hint hint_unif (T &x) Nat → hint_unif &x nat
+hint (T &x) ~ Nat → &x ~ nat
 
 symbol G: ∀(x: Bool) (y: Nat), TYPE
 type λx: T _, λy: T _, G x y
@@ -39,6 +39,6 @@ symbol iz: I z
 //    &x ≡ z   &y ≡ z
 // -------------------
 //    plus &x &y ≡ z
-hint hint_unif (plus &x &y) z → hint_conj (hint_unif &x z) (hint_unif &y z)
+hint (plus &x &y) ~ z → &x ~ z, &y ~ z
 // Trigger the unification problem plus ?1 ?2 ≡ z
 compute H (plus _ _) iz

--- a/tests/OK/unif_hint.lp
+++ b/tests/OK/unif_hint.lp
@@ -23,7 +23,7 @@ rule T nat → Nat
 //  T &x ≡ Nat
 hint (T &x) ≡ Nat → &x ≡ nat
 
-symbol G: ∀(x: Bool) (y: Nat), TYPE
+symbol G: Bool ⇒ Nat ⇒ TYPE
 type λx: T _, λy: T _, G x y
 
 // Need several hints
@@ -33,7 +33,7 @@ symbol plus : Nat ⇒ Nat ⇒ Nat
 rule plus z &n      → &n
  and plus (s &m) &n → s (plus &m &n)
 
-injective symbol I (n: Nat): TYPE
+injective symbol I: Nat ⇒ TYPE
 symbol H (n: Nat): I n ⇒ Nat
 symbol iz: I z
 //    &x ≡ z   &y ≡ z

--- a/tests/OK/unif_hint.lp
+++ b/tests/OK/unif_hint.lp
@@ -8,7 +8,7 @@ rule T bool → Bool
 //   &x ≡ bool
 // --------------
 //  T &x ≡ Bool
-hint (T &x) ~ Bool → &x ~ bool
+hint (T &x) ≡ Bool → &x ≡ bool
 
 symbol f : (Bool ⇒ Bool) ⇒ U
 
@@ -21,7 +21,7 @@ rule T nat → Nat
 //   &x ≡ nat
 // -------------
 //  T &x ≡ Nat
-hint (T &x) ~ Nat → &x ~ nat
+hint (T &x) ≡ Nat → &x ≡ nat
 
 symbol G: ∀(x: Bool) (y: Nat), TYPE
 type λx: T _, λy: T _, G x y
@@ -39,6 +39,6 @@ symbol iz: I z
 //    &x ≡ z   &y ≡ z
 // -------------------
 //    plus &x &y ≡ z
-hint (plus &x &y) ~ z → &x ~ z, &y ~ z
+hint (plus &x &y) ≡ z → &x ≡ z, &y ≡ z
 // Trigger the unification problem plus ?1 ?2 ≡ z
 compute H (plus _ _) iz

--- a/tests/OK/unif_hint.lp
+++ b/tests/OK/unif_hint.lp
@@ -1,0 +1,7 @@
+symbol U: TYPE
+symbol T: U ⇒ TYPE
+symbol bool: U
+symbol Bool: TYPE
+rule T bool → Bool
+
+hint hint_unif (T &x) Bool → hint_unif &x bool


### PR DESCRIPTION
Introduction of unification hints to orient the unification algorithm. Based on <https://doi.org/10.1007/978-3-642-03359-9_8>.

In our framework, a unification hint is represented as a rewriting rule from a unification problem to another one on a special symbol.