### PR TITLE
emacs show-paren-mode was not working with legacy syntax

### DIFF
--- a/editors/emacs/lambdapi.el
+++ b/editors/emacs/lambdapi.el
@@ -91,8 +91,8 @@
 
 (setq lambdapi-mode-legacy-syntax-table
   (let ((syn-table (make-syntax-table)))
-    (modify-syntax-entry ?\( ". 1" syn-table)
-    (modify-syntax-entry ?\) ". 4" syn-table)
+    (modify-syntax-entry ?\( "()1n" syn-table)
+    (modify-syntax-entry ?\) ")(4n" syn-table)
     (modify-syntax-entry ?\; ". 23" syn-table)
     syn-table))
 


### PR DESCRIPTION
it helps when working with legacy syntax

I don't remember exactly when I changed that. I think I read some time ago how tuareg was dealing with ocaml comments ``(* ... *)`` and tried to mimic it since legacy use ``(; ... ;)`` comments

https://github.com/ocaml/tuareg/blob/master/tuareg.el